### PR TITLE
Fix multiple bugs in test suite and web app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ Flask-SocketIO>=5.3.0   # WebSocket support for real-time updates
 Werkzeug>=2.3.0         # WSGI utilities for Flask
 eventlet>=0.33.0        # Async networking library for SocketIO
 python-socketio>=5.8.0  # Socket.IO server implementation
+requests>=2.28.0        # HTTP library for making requests
 
 # Security and Validation
 python-magic>=0.4.27    # MIME type detection and file validation

--- a/src/web/refactored_app.py
+++ b/src/web/refactored_app.py
@@ -6,6 +6,7 @@ service layer, using dependency injection and consistent error handling.
 """
 import os
 import sys
+import time
 from pathlib import Path
 from flask import Flask, render_template, request
 from flask_socketio import SocketIO


### PR DESCRIPTION
This commit addresses two separate issues:

1.  **Missing `requests` dependency:** The `requests` library is required to run the integration test suite, but it was missing from `requirements.txt`. This caused the test runner to fail with a `ModuleNotFoundError`. This change adds the dependency to `requirements.txt`.

2.  **`NameError` in health check endpoint:** The `/api/health` endpoint in `src/web/refactored_app.py` was failing with a `NameError` because it used the `time` module without importing it first. This change adds the necessary `import time` statement.

Both fixes have been verified by running the test suite. The tests that previously failed due to these issues now pass.