### PR TITLE
Fix(image): Handle invalid image files gracefully

### DIFF
--- a/src/core/adapters/legacy_image_converter_adapter.py
+++ b/src/core/adapters/legacy_image_converter_adapter.py
@@ -76,15 +76,11 @@ class LegacyImageConverterAdapter(IImageConverter):
             # Get image info
             try:
                 with Image.open(file_path) as img:
+                    img.verify()  # Verify the image data
                     image_format = img.format
                     image_size = img.size
-            except Exception:
-                # Fallback to extension-based format detection
-                ext = os.path.splitext(file_path)[1].lower()
-                format_map = {'.png': 'PNG', '.jpg': 'JPEG', '.jpeg': 'JPEG', 
-                             '.gif': 'GIF', '.bmp': 'BMP', '.webp': 'WEBP'}
-                image_format = format_map.get(ext, 'Unknown')
-                image_size = (0, 0)
+            except Exception as e:
+                raise ProcessingError(f"Invalid or corrupted image file: {file_path}") from e
             
             # Convert to base64
             base64_data = base64.b64encode(image_data).decode('utf-8')

--- a/tests/integration/test_functionality_verification.py
+++ b/tests/integration/test_functionality_verification.py
@@ -26,6 +26,7 @@ from src.cli import CLI
 from src.web.refactored_app import create_app
 from src.core.services.image_conversion_service import ImageConversionService
 from src.domain.exceptions.base import ImageConverterError
+from src.domain.exceptions.processing import ProcessingError
 
 
 class TestImageCreator:
@@ -404,6 +405,19 @@ class TestServiceLayerIntegration:
         assert error_context is not None
         assert hasattr(error_context, 'user_message')
         assert len(error_context.user_message) > 0
+
+    def test_conversion_of_invalid_image_file(self):
+        """Test that converting a corrupted/invalid image file raises an error."""
+        # Create an invalid image file (just a text file)
+        invalid_image_content = b"this is not a webp file"
+        invalid_image_file = tempfile.NamedTemporaryFile(delete=False, suffix='.webp')
+        invalid_image_file.write(invalid_image_content)
+        invalid_image_file.close()
+        self.test_images.append(invalid_image_file.name)
+
+        # Expect a ProcessingError when trying to convert this file
+        with pytest.raises(ProcessingError):
+            self.conversion_service.convert_image(invalid_image_file.name)
 
 
 class TestBackwardCompatibility:


### PR DESCRIPTION
The image conversion process would previously fail silently if it was given a corrupted or invalid image file. Instead of raising an error, it would fall back to using the file's extension to determine its type and then proceed to Base64-encode the invalid file data. This resulted in incorrect, unusable Data URIs being generated without any warning to the user.

This commit fixes the issue by ensuring the image file is properly verified using Pillow's `verify()` method. If the file cannot be opened or verified as a valid image, a `ProcessingError` is now raised. This provides clear and immediate feedback that the input file is invalid.

A new integration test has been added to confirm that attempting to convert a corrupted image file now correctly raises a `ProcessingError`, preventing future regressions of this bug.