### PR TITLE
fix(cli): Pass force flag to file handler

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -130,7 +130,9 @@ Supported formats: PNG, JPG, JPEG, GIF, BMP, WEBP
                 
                 if output_path:
                     # Save to file using the file handler service
-                    save_result = self._file_handler.save_file(output_content, output_path)
+                    save_result = self._file_handler.save_file(
+                        output_content, output_path, overwrite=force_overwrite
+                    )
                     
                     if save_result:
                         if verbose:
@@ -269,7 +271,9 @@ Supported formats: PNG, JPG, JPEG, GIF, BMP, WEBP
                 
                 if output_path:
                     # Save to file using the file handler service
-                    save_result = self._file_handler.save_file(output_content, output_path)
+                    save_result = self._file_handler.save_file(
+                        output_content, output_path, overwrite=force_overwrite
+                    )
                     
                     if save_result:
                         if verbose:


### PR DESCRIPTION
The CLI was not passing the `--force` flag's value to the file saving service. This meant that even when a user specified `--force`, the application would fail to overwrite an existing output file.

This commit connects the `force_overwrite` variable, derived from the `--force` command-line argument, to the `overwrite` parameter in the `save_file` method of the file handler service. This ensures that the user's intent to overwrite a file is correctly handled.